### PR TITLE
Upgrade to Uppy v2 to pre-sign URLs in batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,31 @@ All notable changes to `laravel-uppy-s3-multipart-upload` will be documented in 
 
 - Add S3 transfer acceleration configuration
 - Update README
+
+## 0.3.1 - 2021-02-27
+
+- Move S3 transfer acceleration config to the package config file
+
+## 0.3.2 - 2021-02-28
+
+- Update the way credentials are passed to use the Credentials class
+
+## 0.3.3 - 2021-03-03
+
+- Remove passing credentials, assuming that AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are set in the .env based on the AWS SDK suggestions
+
+## 0.3.4 - 2021-03-18
+
+- Use Flysystem AWS client
+
+## 0.3.5 - 2021-09-15
+
+- Add support for multiple Uppy instances
+- Update README
+
+## 0.4 - 2021-09-20
+
+- Upgrade Uppy from 1.x to 2.0
+- Add support for pre-sign URLs in batches
+- Update README
+- Add upgrade guide

--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ Add on your `package.json` file the Uppy JS libraries and AlpineJS library:
         ...
     },
     "dependencies": {
-        "@uppy/aws-s3-multipart": "^1.8.12",
-        "@uppy/core": "^1.16.0",
-        "@uppy/drag-drop": "^1.4.24",
-        "@uppy/status-bar": "^1.9.0",
+        "@uppy/aws-s3-multipart": "^2.0.2",
+        "@uppy/core": "^2.0.2",
+        "@uppy/drag-drop": "^2.0.1",
+        "@uppy/status-bar": "^2.0.1"
         ...
     }
     ...

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,31 @@
+# Upgrade Guide
+
+## Upgrading from 0.3.5 to 0.4.0
+
+### To upgrade Uppy from 1.x to 2.0
+
+Update the following dependencies on your `package.json`:
+
+```json
+"dependencies": {
+    ...
+    "@uppy/aws-s3-multipart": "^2.0.2",
+    "@uppy/core": "^2.0.2",
+    "@uppy/drag-drop": "^2.0.1",
+    "@uppy/status-bar": "^2.0.1"
+}
+```
+
+Install the dependencies and compile assets:
+
+```bash
+npm install
+npm run dev
+```
+
+Clear caches:
+
+```bash
+php artisan optimize
+php artisan view:clear
+```

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,7 +9,7 @@ Route::options('/s3/multipart', [UppyS3MultipartController::class, 'createMultip
 
 Route::get('/s3/multipart/{uploadId}', [UppyS3MultipartController::class, 'getUploadedParts']);
 
-Route::get('/s3/multipart/{uploadId}/{partNumber}', [UppyS3MultipartController::class, 'prepareUploadPart']);
+Route::get('/s3/multipart/{uploadId}/batch', [UppyS3MultipartController::class, 'prepareUploadParts']);
 
 Route::post('/s3/multipart/{uploadId}/complete', [UppyS3MultipartController::class, 'completeMultipartUpload']);
 

--- a/src/Http/Controllers/UppyS3MultipartController.php
+++ b/src/Http/Controllers/UppyS3MultipartController.php
@@ -208,7 +208,7 @@ class UppyS3MultipartController extends Controller
     {
         $key = $this->encodeURIComponent($request->input('key'));
 
-        $partNumbers = explode(",", $request->input('partNumbers'));
+        $partNumbers = explode(',', $request->input('partNumbers'));
 
         $presignedUrls = [];
 


### PR DESCRIPTION
Add [Batch pre-signing URLs](https://uppy.io/blog/2021/08/2.0/#Batch-pre-signing-URLs-for-AWS-S3-Multipart) for AWS S3 Multipart.

References:
- https://uppy.io/docs/migration-guides.html#Changes-to-pre-signing-URLs-for-uppy-aws-s3-multipart
- https://uppy.io/blog/2021/08/2.0/#Batch-pre-signing-URLs-for-AWS-S3-Multipart
- https://uppy.io/docs/aws-s3-multipart/#prepareUploadParts-file-partData