### PR TITLE
Remove unnecessary .env vars from setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,6 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=
 AWS_BUCKET=
-AWS_URL="https://s3.amazonaws.com"
-AWS_POST_END_POINT="https://${AWS_BUCKET}.s3.amazonaws.com/"
 ```
 
 To allow direct multipart uploads to your S3 bucket, you need to add some extra configuration on bucket's `CORS configuration`.


### PR DESCRIPTION
`AWS_URL` and `AWS_POST_END_POINT` environment variables are now dynamically determined by the aws-sdk-php package.  Setting these to any value will make the sdk automatically assume you are using a custom endpoint and prevent the use of accelerator,

Fixes #14 