### PR TITLE
Updates to allow the new version of the libraries

### DIFF
--- a/.github/workflows/run-tests-l8.yml
+++ b/.github/workflows/run-tests-l8.yml
@@ -10,13 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         php: [8.1, 8.0]
-        laravel: [9.*, 8.*]
+        laravel: [9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 9.*
             testbench: 7.*
-          - laravel: 8.*
-            testbench: 6.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ Add on your `package.json` file the Uppy JS libraries and AlpineJS library:
 ```
     ...
     "devDependencies": {
-        "alpinejs": "^2.7.3",
+        "alpinejs": "^3.11.1",
         ...
     },
     "dependencies": {
-        "@uppy/aws-s3-multipart": "^2.0.2",
-        "@uppy/core": "^2.0.2",
-        "@uppy/drag-drop": "^2.0.1",
-        "@uppy/status-bar": "^2.0.1"
+        "@uppy/aws-s3-multipart": "^3.1.2",
+        "@uppy/core": "^3.0.5",
+        "@uppy/drag-drop": "^3.0.1",
+        "@uppy/status-bar": "^3.0.1"
         ...
     }
     ...
@@ -65,14 +65,25 @@ Add in your `resources/js/app.js`:
 
 ```javascript
 ...
-require('alpinejs');
+import Alpine from 'alpinejs';
+
+window.Alpine = Alpine;
+
+Alpine.start();
 ```
 
 Install the JS libraries:
 
+for Mix:
 ```
-$ npm install
-$ npm run dev
+npm install
+npm run dev
+```
+
+for Vite:
+```
+npm install
+npm run build
 ```
 
 > You can use CDNs for [Uppy](https://uppy.io/docs/#With-a-script-tag) and [AlpineJS](https://github.com/alpinejs/alpine), if you prefer.
@@ -223,7 +234,7 @@ This package add the following routes:
 POST    /s3/multipart
 OPTIONS /s3/multipart
 GET     /s3/multipart/{uploadId}
-GET     /s3/multipart/{uploadId}/batch
+GET     /s3/multipart/{uploadId}/{partNumber}
 POST    /s3/multipart/{uploadId}/complete
 DELETE  /s3/multipart/{uploadId}
 ```

--- a/resources/views/components/input/uppy.blade.php
+++ b/resources/views/components/input/uppy.blade.php
@@ -24,7 +24,7 @@
             {{ $extraJSForOnUploadSuccess }}
           };
 
-        uppyUpload{{ $hiddenField }} = new Uppy({{ $options }});
+        const uppyUpload{{ $hiddenField }} = new Uppy({{ $options }});
 
         uppyUpload{{ $hiddenField }}
           .use(DragDrop, {{ $dragDropOptions }})

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,14 +3,9 @@
 use Illuminate\Support\Facades\Route;
 use Tapp\LaravelUppyS3MultipartUpload\Http\Controllers\UppyS3MultipartController;
 
+Route::options('/s3/multipart', [UppyS3MultipartController::class, 'createPreflightHeader']);
 Route::post('/s3/multipart', [UppyS3MultipartController::class, 'createMultipartUpload']);
-
-Route::options('/s3/multipart', [UppyS3MultipartController::class, 'createMultipartUploadOptions']);
-
 Route::get('/s3/multipart/{uploadId}', [UppyS3MultipartController::class, 'getUploadedParts']);
-
-Route::get('/s3/multipart/{uploadId}/batch', [UppyS3MultipartController::class, 'prepareUploadParts']);
-
 Route::post('/s3/multipart/{uploadId}/complete', [UppyS3MultipartController::class, 'completeMultipartUpload']);
-
 Route::delete('/s3/multipart/{uploadId}', [UppyS3MultipartController::class, 'abortMultipartUpload']);
+Route::get('/s3/multipart/{uploadId}/{partNumber}', [UppyS3MultipartController::class, 'signPartUpload']);

--- a/src/Http/Controllers/UppyS3MultipartController.php
+++ b/src/Http/Controllers/UppyS3MultipartController.php
@@ -40,15 +40,16 @@ class UppyS3MultipartController extends Controller
     /**
      * Add the preflight response header so it's possible to use the X-CSRF-TOKEN on Uppy request header.
      *
-     * @return \Illuminate\Support\Response  Response with 204 no content
+     * @return string  JSON with 204 status no content
      */
     public function createPreflightHeader(Request $request)
     {
         header('Access-Control-Allow-Headers: Authorization, Content-Type, X-CSRF-TOKEN');
 
-        return response([
-            'message' => 'No content',
-        ], 204);
+        return response()
+            ->json([
+                'message' => 'No content',
+            ], 204);
     }
 
     /**

--- a/src/Http/Controllers/UppyS3MultipartController.php
+++ b/src/Http/Controllers/UppyS3MultipartController.php
@@ -99,7 +99,6 @@ class UppyS3MultipartController extends Controller
      *       }, { signal }).then(assertServerError)
      *
      * @param  \Illuminate\Http\Request  $request
-     * @param  string  $uploadId
      * @return string  JSON with the uploaded parts
      */
     public function createMultipartUpload(Request $request)

--- a/src/Http/Controllers/UppyS3MultipartController.php
+++ b/src/Http/Controllers/UppyS3MultipartController.php
@@ -23,8 +23,9 @@ class UppyS3MultipartController extends Controller
     /**
      * Encode URI.
      *
-     * @param  string  $str
-     * @return string  The encoded URI string
+     * @param string $str
+     *
+     * @return string The encoded URI string
      */
     protected function encodeURIComponent(string $str)
     {
@@ -40,7 +41,7 @@ class UppyS3MultipartController extends Controller
     /**
      * Add the preflight response header so it's possible to use the X-CSRF-TOKEN on Uppy request header.
      *
-     * @return string  JSON with 204 status no content
+     * @return string JSON with 204 status no content
      */
     public function createPreflightHeader(Request $request)
     {
@@ -57,7 +58,6 @@ class UppyS3MultipartController extends Controller
      *
      * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#createmultipartupload  S3 Syntax
      * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html  S3 Syntax
-     *
      * $result = $client->createMultipartUpload([
      *    'ACL' => 'private|public-read|public-read-write|authenticated-read|aws-exec-read|bucket-owner-read|bucket-owner-full-control',
      *    'Bucket' => '<string>', // REQUIRED
@@ -89,17 +89,16 @@ class UppyS3MultipartController extends Controller
      *    'Tagging' => '<string>',
      *    'WebsiteRedirectLocation' => '<string>',
      * ]);
-     *
      * @see https://github.com/transloadit/uppy/blob/master/packages/%40uppy/aws-s3-multipart/src/index.js  Uppy call to this endpoint
-     *
      * return this.#client.post('s3/multipart', {
      *           filename: file.name,
      *           type: file.type,
      *           metadata,
      *       }, { signal }).then(assertServerError)
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return string  JSON with the uploaded parts
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return string JSON with the uploaded parts
      */
     public function createMultipartUpload(Request $request)
     {
@@ -134,9 +133,10 @@ class UppyS3MultipartController extends Controller
     /**
      * List the multipart uploaded parts.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $uploadId
-     * @return string  JSON with the uploaded parts
+     * @param \Illuminate\Http\Request $request
+     * @param string                   $uploadId
+     *
+     * @return string JSON with the uploaded parts
      */
     public function getUploadedParts(Request $request, string $uploadId)
     {
@@ -151,9 +151,7 @@ class UppyS3MultipartController extends Controller
     /**
      * Get the uploaded parts. Retry the part if it's truncated.
      *
-     *
      * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#listparts  S3 Syntax
-     *
      * $result = $client->listParts([
      *           'Bucket' => '<string>', // REQUIRED
      *           'ExpectedBucketOwner' => '<string>',
@@ -163,15 +161,14 @@ class UppyS3MultipartController extends Controller
      *           'RequestPayer' => 'requester',
      *           'UploadId' => '<string>', // REQUIRED
      *       ]);
-     *
      * @see https://github.com/transloadit/uppy/blob/master/packages/%40uppy/aws-s3-multipart/src/index.js  Uppy call to this endpoint
-     *
      * return this.#client.get(`s3/multipart/${uploadId}?key=${filename}`, { signal })
      *          .then(assertServerError)
      *
-     * @param  string  $key
-     * @param  string  $uploadId
-     * @param  int  $partIndex
+     * @param string $key
+     * @param string $uploadId
+     * @param int    $partIndex
+     *
      * @return \Illuminate\Support\Collection
      */
     private function listPartsPage(string $key, string $uploadId, int $partIndex, $parts = null)
@@ -201,7 +198,6 @@ class UppyS3MultipartController extends Controller
      * Completes a multipart upload by assembling previously uploaded parts.
      *
      * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#completemultipartupload  S3 Syntax
-     *
      * $result = $client->completeMultipartUpload([
      *           'Bucket' => '<string>', // REQUIRED
      *           'ExpectedBucketOwner' => '<string>',
@@ -218,14 +214,13 @@ class UppyS3MultipartController extends Controller
      *           'RequestPayer' => 'requester',
      *           'UploadId' => '<string>', // REQUIRED
      *       ]);
-     *
      * @see https://github.com/transloadit/uppy/blob/master/packages/%40uppy/aws-s3-multipart/src/index.js  Uppy call to this endpoint
-     *
      * return this.#client.post(`s3/multipart/${uploadIdEnc}/complete?key=${filename}`, { parts }, { signal })
      *           .then(assertServerError)
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $uploadId
+     * @param \Illuminate\Http\Request $request
+     * @param string                   $uploadId
+     *
      * @return string
      */
     public function completeMultipartUpload(Request $request, string $uploadId)
@@ -264,7 +259,6 @@ class UppyS3MultipartController extends Controller
      * Aborts a multipart upload, deleting the uploaded parts.
      *
      * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#abortmultipartupload   S3 Syntax
-     *
      * $result = $client->abortMultipartUpload([
      *           'Bucket' => '<string>', // REQUIRED
      *           'ExpectedBucketOwner' => '<string>',
@@ -272,15 +266,14 @@ class UppyS3MultipartController extends Controller
      *           'RequestPayer' => 'requester',
      *           'UploadId' => '<string>', // REQUIRED
      *       ]);
-     *
      * @see https://github.com/transloadit/uppy/blob/master/packages/%40uppy/aws-s3-multipart/src/index.js  Uppy call to this endpoint
-     *
      * return this.#client.delete(`s3/multipart/${uploadIdEnc}?key=${filename}`, undefined, { signal })
      *           .then(assertServerError)
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  string  $uploadId
-     * @return string  JSON empty
+     * @param \Illuminate\Http\Request $request
+     * @param string                   $uploadId
+     *
+     * @return string JSON empty
      */
     public function abortMultipartUpload(Request $request, string $uploadId)
     {
@@ -299,8 +292,9 @@ class UppyS3MultipartController extends Controller
     /**
      * Presign a URL for a part.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @return string  JSON with the URL
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return string JSON with the URL
      */
     public function signPartUpload(Request $request)
     {
@@ -316,7 +310,6 @@ class UppyS3MultipartController extends Controller
      * Get the presigned URL for a part.
      *
      * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#uploadpart  S3 Syntax
-     *
      * $result = $client->uploadPart([
      *           'Body' => <string || resource || Psr\Http\Message\StreamInterface>,
      *           'Bucket' => '<string>', // REQUIRED
@@ -332,14 +325,13 @@ class UppyS3MultipartController extends Controller
      *           'SourceFile' => '<string>',
      *           'UploadId' => '<string>', // REQUIRED
      *       ]);
-     *
      * @see https://github.com/transloadit/uppy/blob/master/packages/%40uppy/aws-s3-multipart/src/index.js  Uppy call to this endpoint
-     *
      * return this.#client.get(`s3/multipart/${uploadId}/${partNumber}?key=${filename}`, { signal })
      *           .then(assertServerError)
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  int  $partNumber
+     * @param \Illuminate\Http\Request $request
+     * @param int                      $partNumber
+     *
      * @return string
      */
     public function getSignedUrl(Request $request, int $partNumber)


### PR DESCRIPTION
Issue: https://github.com/TappNetwork/laravel-uppy-s3-multipart-upload/issues/17

- add the new `signPartUpload` method
- remove `prepareUploadParts` method
- refactor comments to docblock
- add type hints
- update README instructions to new version of the JS libraries