### PR TITLE
Prevent Collisions

### DIFF
--- a/src/Http/Controllers/UppyS3MultipartController.php
+++ b/src/Http/Controllers/UppyS3MultipartController.php
@@ -106,7 +106,7 @@ class UppyS3MultipartController extends Controller
         $filenameRequest = $request->input('filename');
         $fileExtension = pathinfo($filenameRequest, PATHINFO_EXTENSION);
         $folder = config('uppy-s3-multipart-upload.s3.bucket.folder') ? config('uppy-s3-multipart-upload.s3.bucket.folder').'/' : '';
-	    $key = $folder.Str::ulid().'.'.$fileExtension;
+        $key = $folder.Str::ulid().'.'.$fileExtension;
 
         try {
             $result = $this->client->createMultipartUpload([

--- a/src/Http/Controllers/UppyS3MultipartController.php
+++ b/src/Http/Controllers/UppyS3MultipartController.php
@@ -104,10 +104,9 @@ class UppyS3MultipartController extends Controller
     {
         $type = $request->input('type');
         $filenameRequest = $request->input('filename');
-        $fileName = pathinfo($filenameRequest, PATHINFO_FILENAME);
         $fileExtension = pathinfo($filenameRequest, PATHINFO_EXTENSION);
         $folder = config('uppy-s3-multipart-upload.s3.bucket.folder') ? config('uppy-s3-multipart-upload.s3.bucket.folder').'/' : '';
-        $key = $folder.Str::of($fileName.'_'.microtime())->slug('_').'.'.$fileExtension;
+	$key = $folder.Str::uuid().'.'.$fileExtension;
 
         try {
             $result = $this->client->createMultipartUpload([

--- a/src/Http/Controllers/UppyS3MultipartController.php
+++ b/src/Http/Controllers/UppyS3MultipartController.php
@@ -106,7 +106,7 @@ class UppyS3MultipartController extends Controller
         $filenameRequest = $request->input('filename');
         $fileExtension = pathinfo($filenameRequest, PATHINFO_EXTENSION);
         $folder = config('uppy-s3-multipart-upload.s3.bucket.folder') ? config('uppy-s3-multipart-upload.s3.bucket.folder').'/' : '';
-	$key = $folder.Str::uuid().'.'.$fileExtension;
+	$key = $folder.Str::ulid().'.'.$fileExtension;
 
         try {
             $result = $this->client->createMultipartUpload([

--- a/src/Http/Controllers/UppyS3MultipartController.php
+++ b/src/Http/Controllers/UppyS3MultipartController.php
@@ -106,7 +106,7 @@ class UppyS3MultipartController extends Controller
         $filenameRequest = $request->input('filename');
         $fileExtension = pathinfo($filenameRequest, PATHINFO_EXTENSION);
         $folder = config('uppy-s3-multipart-upload.s3.bucket.folder') ? config('uppy-s3-multipart-upload.s3.bucket.folder').'/' : '';
-	$key = $folder.Str::ulid().'.'.$fileExtension;
+	    $key = $folder.Str::ulid().'.'.$fileExtension;
 
         try {
             $result = $this->client->createMultipartUpload([


### PR DESCRIPTION
Sometimes when many files that have the same name are uploaded simultaneously a naming collision happens. This pull request uses the [ULID](https://laravel.com/docs/10.x/helpers#method-str-ulid) helper that Laravel provides to prevent any chance of a name collision.