### PR TITLE
Laravel 12 Compatibility ... continued

### DIFF
--- a/.github/workflows/run-tests-l8.yml
+++ b/.github/workflows/run-tests-l8.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.3, 8.2, 8.1]
-        laravel: [12.*, 11.*, 10.*]
+        php: [8.3, 8.2, 8.1, 8.0]
+        laravel: [12.*, 11.*, 10.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - php: 8.3
@@ -28,6 +28,9 @@ jobs:
           - php: 8.1
             laravel: 10.*
             testbench: 8.*
+          - php: 8.0
+            laravel: 9.*
+            testbench: 7.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests-l8.yml
+++ b/.github/workflows/run-tests-l8.yml
@@ -9,12 +9,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.1, 8.0]
-        laravel: [9.*]
+        php: [8.3, 8.2, 8.1]
+        laravel: [12.*, 11.*, 10.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 9.*
-            testbench: 7.*
+          - php: 8.3
+            laravel: 12.*
+            testbench: 9.*
+          - php: 8.2
+            laravel: 12.*
+            testbench: 9.*
+          - php: 8.2
+            laravel: 11.*
+            testbench: 8.*
+          - php: 8.1
+            laravel: 11.*
+            testbench: 8.*
+          - php: 8.1
+            laravel: 10.*
+            testbench: 8.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/run-tests-l8.yml
+++ b/.github/workflows/run-tests-l8.yml
@@ -12,24 +12,33 @@ jobs:
         php: [8.3, 8.2, 8.1, 8.0]
         laravel: [12.*, 11.*, 10.*, 9.*]
         dependency-version: [prefer-lowest, prefer-stable]
-        include:
-          - php: 8.3
-            laravel: 12.*
-            testbench: 9.*
-          - php: 8.2
-            laravel: 12.*
-            testbench: 9.*
-          - php: 8.2
-            laravel: 11.*
-            testbench: 8.*
-          - php: 8.1
-            laravel: 11.*
-            testbench: 8.*
-          - php: 8.1
-            laravel: 10.*
-            testbench: 8.*
+        exclude:
           - php: 8.0
+            laravel: 12.*
+          - php: 8.0
+            laravel: 11.*
+          - php: 8.0
+            laravel: 10.*
+          - php: 8.1
+            laravel: 12.*
+          - php: 8.1
+            laravel: 11.*
+          - php: 8.2
             laravel: 9.*
+          - php: 8.3
+            laravel: 9.*
+          - php: 8.3
+            laravel: 10.*
+          - php: 8.3
+            laravel: 11.*
+        include:
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 9.*
             testbench: 7.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
@@ -53,7 +62,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "symfony/console:>=4.3.4" "mockery/mockery:^1.3.2" --no-interaction --no-update
+          composer require --dev "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "mockery/mockery:^1.3.2" --no-interaction --no-update
           composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
       # - name: Execute tests
       #   run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.4|^8.0",
         "league/flysystem-aws-s3-v3": "^3.0",
         "spatie/laravel-package-tools": "^1.1",
-        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0"
+        "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0 | ^7.0 | ^8.0 | ^9.0",

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,14 @@
         "illuminate/contracts": "^8.0|^9.0|^10.0|^11.0|^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^6.0 | ^7.0 | ^8.0 | ^9.0",
+        "laravel/framework": "12.*",
+        "mockery/mockery": "^1.3.2",
+        "orchestra/testbench": "10.*",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.3",
         "spatie/laravel-ray": "^1.9",
-        "vimeo/psalm": "^4.4"
+        "vimeo/psalm": "^4.4 || ^5.0 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
# Details

This PR is a continuation of #28 from @azimidev 

You requested in https://github.com/TappNetwork/laravel-uppy-s3-multipart-upload/pull/28#pullrequestreview-2747261490 that he add 12 to the matrix. But you didn't have **anything after L9** in the testing matrix.

I added all of them up to L12. Hopefully this works and you can quickly approve this because I intend to use it.

P.S. Sorry @azimidev. You didn't check the box to allow edits so I had to open a new PR.

Thanks!